### PR TITLE
chore: remove Dependabot config (migrating to Renovate)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
We are rolling out **Renovate** across the org to handle dependency updates.

This PR removes the Dependabot configuration so the two bots don't both raise update PRs. Renovate is configured org-wide and will take over from here.

_Opened automatically by `scripts/remove-dependabot/remove_dependabot.py`._